### PR TITLE
Further Fixed UDP Binding Issues to Work with a Declared Source

### DIFF
--- a/seagull/trunk/src/library-trans-ip/C_Socket.cpp
+++ b/seagull/trunk/src/library-trans-ip/C_Socket.cpp
@@ -603,6 +603,7 @@ int C_SocketServer::_open(size_t P_buffer_size,
 
 C_SocketClient::C_SocketClient(C_SocketClient& P_Socket) 
   : C_SocketWithData (P_Socket) {
+  m_hasSource = P_Socket. m_remote_addr_info->m_hasSource;
 }
 
 C_SocketClient::C_SocketClient(T_SocketType P_type, 
@@ -613,6 +614,8 @@ C_SocketClient::C_SocketClient(T_SocketType P_type,
   : C_SocketWithData(P_type, P_addr, P_channel_id, 
                      P_read_buf_size, P_segm_buf_size) {
   SOCKET_DEBUG(0, "C_SocketClient::C_SocketClient() id=" << m_socket_id);
+	  
+  m_hasSource = P_addr->m_hasSource;
 }
 
 C_SocketClient::~C_SocketClient() {
@@ -664,13 +667,17 @@ int C_SocketClient::_open(T_pOpenStatus  P_status,
       }
     } else {
 	    
-      /* UDP Does not need to bind first */
+      /* UDP Does not need to bind first unless source is declared */
       if(m_type != E_SOCKET_UDP_MODE) {
         L_rc = call_bind(m_socket_id, 
                        (sockaddr *)(void *)&(m_remote_addr_info->m_addr_src),
                        SOCKADDR_IN_SIZE(&(m_remote_addr_info->m_addr_src)));
-        } else {
-	  L_rc = 0;
+        } else if (m_type == E_SOCKET_UDP_MODE && m_hasSource == true) { 
+          L_rc = call_bind(m_socket_id, 
+                       (sockaddr *)(void *)&(m_remote_addr_info->m_addr_src),
+                       SOCKADDR_IN_SIZE(&(m_remote_addr_info->m_addr_src)));
+        } else { 
+          L_rc = 0;
         }
 	    
        if (L_rc) {

--- a/seagull/trunk/src/library-trans-ip/C_Socket.hpp
+++ b/seagull/trunk/src/library-trans-ip/C_Socket.hpp
@@ -241,6 +241,9 @@ public:
                      size_t        P_buffer_size,
                      C_ProtocolBinaryFrame *P_protocol);
   int _read ();
+	
+protected:
+  bool m_hasSource;
 
 } ;
 

--- a/seagull/trunk/src/library-trans-ip/C_TransIP.cpp
+++ b/seagull/trunk/src/library-trans-ip/C_TransIP.cpp
@@ -775,6 +775,8 @@ bool C_TransIP::analyze_open_string (char *P_buf, T_pIpAddr P_addr) {
 		  char*,sizeof(char),
 		  strlen(L_tmp)+1);
       strcpy(P_addr->m_open_src, L_tmp);
+	    
+      P_addr->m_hasSource = true;
     } 
   }
 

--- a/seagull/trunk/src/library-trans-ip/S_IpAddr.hpp
+++ b/seagull/trunk/src/library-trans-ip/S_IpAddr.hpp
@@ -47,6 +47,8 @@ typedef struct _struct_ip_addr {
   long                    m_port_src    ;
   char                   *m_ip_src      ;
   T_SockAddrStorage       m_addr_src    ;
+  
+  bool                    m_hasSource   ;
 
 } T_IpAddr, *T_pIpAddr ;
 


### PR DESCRIPTION
Seagull allows the ability to declare a source address in the config XML file. Originally (back in July of 2018), I fixed the issue of UDP not binding. It turns out UDP would only bind if a source was given, which should be optional. The following updates fix it so the source address is optional but does work when defined in the XML configuration file.