### PR TITLE
Work around -Werror=format-truncation compilation errors.

### DIFF
--- a/seagull/trunk/src/common/Utils.hpp
+++ b/seagull/trunk/src/common/Utils.hpp
@@ -59,6 +59,11 @@ typedef unsigned char boolean ;
 #endif /* false */
 #endif /* LOCAL_BOOLEAN */
 
+// Standard error/log message length limit
+#ifndef MAX_LOG_LENGTH
+#define MAX_LOG_LENGTH 1200
+#endif
+
 //
 // Memory allocation general macros
 

--- a/seagull/trunk/src/library-trans-ip/C_TransIP.cpp
+++ b/seagull/trunk/src/library-trans-ip/C_TransIP.cpp
@@ -37,39 +37,39 @@
 #define GEN_ERROR(l,a) iostream_error << a << iostream_endl << iostream_flush ; 
 
 #define LOG_ERROR(m) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (char*)(m)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (char*)(m)) ; \
 (*m_logError)(L_err); \
 }
 
 #define LOG_ERROR_P1(m,P1) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (char*)(m), (P1)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (char*)(m), (P1)) ; \
 (*m_logError)(L_err); \
 }
 
 #define LOG_ERROR_P2(m,P1,P2) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (char*)(m), (P1),(P2)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (char*)(m), (P1),(P2)) ; \
 (*m_logError)(L_err); \
 }
 
 
 #define LOG_ALL(m) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (char*)(m)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (char*)(m)) ; \
 (*m_logInfo)(L_msg); \
 }
 
 #define LOG_ALL_P1(m,P1) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (char*)(m), (P1)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (char*)(m), (P1)) ; \
 (*m_logInfo)(L_msg); \
 }
 
 #define LOG_ALL_P2(m,P1,P2) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (char*)(m), (P1),(P2)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (char*)(m), (P1),(P2)) ; \
 (*m_logInfo)(L_msg); \
 }
 

--- a/seagull/trunk/src/library-trans-octcap32/C_TCAPMsgBuildContextNoFlavour.body
+++ b/seagull/trunk/src/library-trans-octcap32/C_TCAPMsgBuildContextNoFlavour.body
@@ -26,39 +26,39 @@
 #endif
 
 #define LOG_ERROR(m) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m)) ; \
 (*m_log_error)(L_err); \
 }
 
 #define LOG_ERROR_P1(m,P1) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m), (P1)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m), (P1)) ; \
 (*m_log_error)(L_err); \
 }
 
 #define LOG_ERROR_P2(m,P1,P2) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m), (P1),(P2)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m), (P1),(P2)) ; \
 (*m_log_error)(L_err); \
 }
 
 
 #define LOG_ALL(m) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m)) ; \
 (*m_log_info)(L_msg); \
 }
 
 #define LOG_ALL_P1(m,P1) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m), (P1)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m), (P1)) ; \
 (*m_log_info)(L_msg); \
 }
 
 #define LOG_ALL_P2(m,P1,P2) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m), (P1),(P2)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m), (P1),(P2)) ; \
 (*m_log_info)(L_msg); \
 }
 

--- a/seagull/trunk/src/library-trans-octcap32/C_TcapStackNoFlavour.body
+++ b/seagull/trunk/src/library-trans-octcap32/C_TcapStackNoFlavour.body
@@ -138,45 +138,45 @@ static const char* _Stack_Header =
 ;
 
 #define LOG_ERROR(m) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m)) ; \
 (*m_log_error)(L_err); \
 }
 
 #define LOG_ERROR_P1(m,P1) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m), (P1)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m), (P1)) ; \
 (*m_log_error)(L_err); \
 }
 
 #define LOG_ERROR_P2(m,P1,P2) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m), (P1),(P2)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m), (P1),(P2)) ; \
 (*m_log_error)(L_err); \
 }
 
 #define LOG_ERROR_P3(m,P1,P2,P3) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m), (P1),(P2),(P3)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m), (P1),(P2),(P3)) ; \
 (*m_log_error)(L_err); \
 }
 
 
 #define LOG_ALL(m) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m)) ; \
 (*m_log_info)(L_msg); \
 }
 
 #define LOG_ALL_P1(m,P1) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m), (P1)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m), (P1)) ; \
 (*m_log_info)(L_msg); \
 }
 
 #define LOG_ALL_P2(m,P1,P2) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m), (P1),(P2)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m), (P1),(P2)) ; \
 (*m_log_info)(L_msg); \
 }
 

--- a/seagull/trunk/src/library-trans-octcap32/C_TransOCTcap32.cpp
+++ b/seagull/trunk/src/library-trans-octcap32/C_TransOCTcap32.cpp
@@ -32,39 +32,39 @@
 
 
 #define LOG_ERROR(m) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m)) ; \
 (*m_log_error)(L_err); \
 }
 
 #define LOG_ERROR_P1(m,P1) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m), (P1)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m), (P1)) ; \
 (*m_log_error)(L_err); \
 }
 
 #define LOG_ERROR_P2(m,P1,P2) { \
- char L_err [100] ; \
- snprintf(L_err, 100, (m), (P1),(P2)) ; \
+ char L_err [MAX_LOG_LENGTH] ; \
+ snprintf(L_err, MAX_LOG_LENGTH, (m), (P1),(P2)) ; \
 (*m_log_error)(L_err); \
 }
 
 
 #define LOG_ALL(m) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m)) ; \
 (*m_log_info)(L_msg); \
 }
 
 #define LOG_ALL_P1(m,P1) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m), (P1)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m), (P1)) ; \
 (*m_log_info)(L_msg); \
 }
 
 #define LOG_ALL_P2(m,P1,P2) { \
- char L_msg [100] ; \
- snprintf(L_msg, 100, (m), (P1),(P2)) ; \
+ char L_msg [MAX_LOG_LENGTH] ; \
+ snprintf(L_msg, MAX_LOG_LENGTH, (m), (P1),(P2)) ; \
 (*m_log_info)(L_msg); \
 }
 


### PR DESCRIPTION
When -Werror=format-truncation is enabled, various warnings break the
build like:

[Compiling library-trans-ip/C_TransIP.cpp]
library-trans-ip/C_TransIP.cpp: In member function 'void C_TransIP::analyze_optional_init_string(char*)':
library-trans-ip/C_TransIP.cpp:676:6: error: '%s' directive output may be truncated writing up to 254 bytes into a region of size 56 [-Werror=format-truncation=]
 void C_TransIP::analyze_optional_init_string(char *P_buf) {
      ^~~~~~~~~
library-trans-ip/C_TransIP.cpp:66:10: note: 'snprintf' output between 46 and 300 bytes into a destination of size 100
  snprintf(L_msg, 100, (char*)(m), (P1)) ; \
  ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
library-trans-ip/C_TransIP.cpp:710:9: note: in expansion of macro 'LOG_ALL_P1'
         LOG_ALL_P1("Unknown parameter value for close-wait-ms: [%s]", L_tmp);
         ^~~~~~~~~~
library-trans-ip/C_TransIP.cpp: In member function 'int C_TransIP::extract_ip_addr(T_pIpAddr)':
library-trans-ip/C_TransIP.cpp:846:5: error: '%s' directive output may be truncated writing up to 1023 bytes into a region of size 84 [-Werror=format-truncation=]
 int C_TransIP::extract_ip_addr(T_pIpAddr P_pIpAddr) {
     ^~~~~~~~~
library-trans-ip/C_TransIP.cpp:66:10: note: 'snprintf' output between 18 and 1041 bytes into a destination of size 100
...
cc1plus: all warnings being treated as errors
make[1]: *** [.../seagull/trunk/src/work-1.8.3/dep-libtrans_ip.so.mk:55: .../seagull/trunk/src/work-1.8.3/C_TransIP.o] Error 1

The longest string being snprintf'ed is up to just over 1000 bytes,
so this simply defines the error/log message size to 1200 bytes.