### PR TITLE
Update of Docker file: sctplib and socketapi URLs made secure

### DIFF
--- a/docker/ubuntu-18.04/Dockerfile
+++ b/docker/ubuntu-18.04/Dockerfile
@@ -8,8 +8,8 @@ RUN    mkdir -p ~/opt/src \
     && git clone https://github.com/codeghar/Seagull.git seagull
 
 RUN    mkdir -p ~/opt/src/seagull/seagull/trunk/src/external-lib-src \
-    && curl -o ~/opt/src/seagull/seagull/trunk/src/external-lib-src/sctplib-1.0.15.tar.gz http://www.sctp.de/download/sctplib-1.0.15.tar.gz \
-    && curl -o ~/opt/src/seagull/seagull/trunk/src/external-lib-src/socketapi-2.2.8.tar.gz http://www.sctp.de/download/socketapi-2.2.8.tar.gz \
+    && curl -o ~/opt/src/seagull/seagull/trunk/src/external-lib-src/sctplib-1.0.15.tar.gz https://www.sctp.de/download/sctplib-1.0.15.tar.gz \
+    && curl -o ~/opt/src/seagull/seagull/trunk/src/external-lib-src/socketapi-2.2.8.tar.gz https://www.sctp.de/download/socketapi-2.2.8.tar.gz \
     && curl -o ~/opt/src/seagull/seagull/trunk/src/external-lib-src/openssl-1.0.2e.tar.gz https://www.openssl.org/source/openssl-1.0.2e.tar.gz
 
 RUN    cd ~/opt/src/seagull/seagull/trunk/src \


### PR DESCRIPTION
Original was "http" and redirected to "https" and made the docker build fail.